### PR TITLE
Removed support line— AudioWorkletProcessor is now supported by all b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Phaze is a real-time pitch-shifter based on the the method described [here][1], implemented as a Web Audio [AudioWorkletProcessor][2]. It supports mono and multi-channel processing.
 
-Please note that AudioWorkletProcessors are currently (January 2021) only supported in Chrome and Firefox.
-
 [1]: https://www.researchgate.net/publication/228756320_New_phase-vocoder_techniques_for_real-time_pitch_shifting
 [2]: https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor
 


### PR DESCRIPTION
…rowsers.

According to the MDN page (linked in the readme), AudioWorkletProcessor is now supported by all browsers of any reasonable significance, desktop and mobile (so not `elinks`, but pretty much everything else 😂)